### PR TITLE
fix ops_ip_copy bug

### DIFF
--- a/src/obproxy/iocore/net/ob_inet.h
+++ b/src/obproxy/iocore/net/ob_inet.h
@@ -562,6 +562,10 @@ inline bool ops_ip_copy(sockaddr &dst, const sockaddr &src)
     case AF_INET6:
       n2 = sizeof(sockaddr_in6);
       break;
+
+    default:
+      n2 = sizeof(sockaddr_in);
+      break;
   }
   if (n && n <= n2) {
     MEMCPY(&dst, &src, n);


### PR DESCRIPTION
Fix the problem that ops_ip_copy will not copy when det has no family