### PR TITLE
Bugfix:Fixed obproxyd.sh script terminator error and description error

### DIFF
--- a/script/deploy/obproxyd.sh
+++ b/script/deploy/obproxyd.sh
@@ -94,7 +94,7 @@ function check_opt()
     else
       echo "obproxy config server url:$OBPROXY_CONFIG_SERVER_URL"
       OBPROXY_CONFIG_SERVER_URL_ARG=" -u $OBPROXY_CONFIG_SERVER_URL"
-    if
+    fi
 
     # check PORT
     if [ -z $OBPROXY_PORT ]

--- a/src/obproxy/ob_proxy_main.cpp
+++ b/src/obproxy/ob_proxy_main.cpp
@@ -145,7 +145,7 @@ void ObProxyMain::print_usage() const
   MPRINT("  -R,--releaseid           RELEASEID     current obproxy kernel release id");
   MPRINT("  -t,--regression_test     TEST_NAME     regression test");
   MPRINT("example:");
-  MPRINT("  run without config server:");
+  MPRINT("  run without root service list:");
   MPRINT("    ./bin/obproxy -p6789 -r'ip:port;ip:port' -n test -o enable_cluster_checkout=false,syslog_level=INFO");
   MPRINT(" OR ./bin/obproxy -p6789 -r'ip:port;ip:port' -c 'ob_test' -n test -o syslog_level=INFO \n");
   MPRINT("  run with config server:");


### PR DESCRIPTION
1. Fixed an issue with terminator errors causing scripts to not run
2. Fixed a problem with incorrect caption description