### PR TITLE
feat: enable weakly consistent read for users on obproxy V4

### DIFF
--- a/src/obproxy/obutils/ob_config_processor.cpp
+++ b/src/obproxy/obutils/ob_config_processor.cpp
@@ -768,6 +768,22 @@ int ObConfigProcessor::get_proxy_config_int_item(const ObVipAddr &addr, const Ob
   return ret;
 }
 
+int ObConfigProcessor::get_proxy_config_list_item(const ObVipAddr &addr, const ObString &cluster_name,
+                                                  const ObString &tenant_name, const ObString& name,
+                                                  ObConfigStrListItem &ret_item)
+{
+  int ret = OB_SUCCESS;
+  ObConfigItem item;
+  if (OB_FAIL(get_proxy_config(addr, cluster_name, tenant_name, name, item))) {
+    LOG_WARN("get proxy config failed", K(addr), K(cluster_name), K(tenant_name), K(name), K(ret));
+  } else {
+    ret_item = item.str();
+    LOG_DEBUG("get list item succ", K(ret_item));
+  }
+
+  return ret;
+}
+
 } // end of obutils
 } // end of obproxy
 } // end of oceanbase

--- a/src/obproxy/obutils/ob_config_processor.cpp
+++ b/src/obproxy/obutils/ob_config_processor.cpp
@@ -768,7 +768,7 @@ int ObConfigProcessor::get_proxy_config_int_item(const ObVipAddr &addr, const Ob
   return ret;
 }
 
-int ObConfigProcessor::get_proxy_config_list_item(const ObVipAddr &addr, const ObString &cluster_name,
+int ObConfigProcessor::get_proxy_config_strlist_item(const ObVipAddr &addr, const ObString &cluster_name,
                                                   const ObString &tenant_name, const ObString& name,
                                                   ObConfigStrListItem &ret_item)
 {

--- a/src/obproxy/obutils/ob_config_processor.h
+++ b/src/obproxy/obutils/ob_config_processor.h
@@ -116,7 +116,7 @@ public:
   int get_proxy_config_int_item(const ObVipAddr &addr, const common::ObString &cluster_name,
                                  const common::ObString &tenant_name, const common::ObString& name,
                                  common::ObConfigIntItem &ret_item);
-  int get_proxy_config_list_item(const ObVipAddr &addr, const common::ObString &cluster_name,
+  int get_proxy_config_strlist_item(const ObVipAddr &addr, const common::ObString &cluster_name,
                                  const common::ObString &tenant_name, const common::ObString& name,
                                  common::ObConfigStrListItem &ret_item);
   int get_proxy_config_with_level(const ObVipAddr &addr, const common::ObString &cluster_name,

--- a/src/obproxy/obutils/ob_config_processor.h
+++ b/src/obproxy/obutils/ob_config_processor.h
@@ -116,6 +116,9 @@ public:
   int get_proxy_config_int_item(const ObVipAddr &addr, const common::ObString &cluster_name,
                                  const common::ObString &tenant_name, const common::ObString& name,
                                  common::ObConfigIntItem &ret_item);
+  int get_proxy_config_list_item(const ObVipAddr &addr, const common::ObString &cluster_name,
+                                 const common::ObString &tenant_name, const common::ObString& name,
+                                 common::ObConfigStrListItem &ret_item);
   int get_proxy_config_with_level(const ObVipAddr &addr, const common::ObString &cluster_name,
                                   const common::ObString &tenant_name, const common::ObString& name,
                                   common::ObConfigItem &ret_item, const ObString level, bool &found);

--- a/src/obproxy/obutils/ob_proxy_config.h
+++ b/src/obproxy/obutils/ob_proxy_config.h
@@ -486,10 +486,7 @@ public:
   DEF_BOOL(enable_read_write_split, "false", "if enabled, use read write split mode", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_SYS);
   DEF_BOOL(enable_transaction_split, "false", "if enabled, support transaction split", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_SYS);
 
-  // user list
   DEF_STR_LIST(weak_read_user_list, "", "weak read for list of users, format user1;user2", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_USER);
-  
-  // DEF_STR_LIST(read_only_user_list, "", "read only for list of users, format user1;user2", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_USER);
 
   // binlog service
   DEF_STR(binlog_service_ip, "", "binlog service ip, format ip1:sql_port1", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_SYS);

--- a/src/obproxy/obutils/ob_proxy_config.h
+++ b/src/obproxy/obutils/ob_proxy_config.h
@@ -486,6 +486,11 @@ public:
   DEF_BOOL(enable_read_write_split, "false", "if enabled, use read write split mode", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_SYS);
   DEF_BOOL(enable_transaction_split, "false", "if enabled, support transaction split", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_SYS);
 
+  // user list
+  DEF_STR_LIST(weak_read_user_list, "", "weak read for list of users, format user1;user2", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_USER);
+  
+  // DEF_STR_LIST(read_only_user_list, "", "read only for list of users, format user1;user2", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_USER);
+
   // binlog service
   DEF_STR(binlog_service_ip, "", "binlog service ip, format ip1:sql_port1", CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_SYS);
   DEF_BOOL(enable_binlog_service, "false", "if enabled, obproxy will send binlog request to OBLogProxy",  CFG_NO_NEED_REBOOT, CFG_SECTION_OBPROXY, CFG_VISIBLE_LEVEL_SYS);

--- a/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
+++ b/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
@@ -6132,7 +6132,7 @@ int ObMysqlTransact::ObTransState::get_config_item(const ObString& cluster_name,
 
   if (OB_SUCC(ret)) {
     ObConfigStrListItem strlist_item;
-    if (OB_FAIL(get_global_config_processor().get_proxy_config_list_item(
+    if (OB_FAIL(get_global_config_processor().get_proxy_config_strlist_item(
          addr, cluster_name, tenant_name, "weak_read_user_list", strlist_item))) {
       LOG_WARN("get vip weak_read_user_list failed", K(addr), K(cluster_name), K(tenant_name), K(ret));
     } else {

--- a/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
+++ b/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
@@ -6154,9 +6154,9 @@ int ObMysqlTransact::ObTransState::get_config_item(const ObString& cluster_name,
           }
         }
       }
-      bool is_request_follower = true;
+      bool is_request_follower = false;
       if (is_weak_read_user){
-        is_request_follower = (RequestFollower == 1);
+        is_request_follower = true;
       } else{
         ObConfigIntItem int_item;
         if (OB_FAIL(get_global_config_processor().get_proxy_config_int_item(

--- a/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
+++ b/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
@@ -6131,36 +6131,47 @@ int ObMysqlTransact::ObTransState::get_config_item(const ObString& cluster_name,
   }
 
   if (OB_SUCC(ret)) {
-    bool is_weak_read_user = false;
-    int64_t total_size = get_global_proxy_config().weak_read_user_list.size();
-    if (OB_UNLIKELY(total_size > 0)) {
-      ObMysqlAuthRequest &auth_req = session_info.get_login_req();
-      ObHSRResult &hsr = auth_req.get_hsr_result();
-      char user_buf[MAX_VALUE_LENGTH];
-      for (int64_t i = 0; OB_SUCC(ret) && i < total_size; ++i) {
-        user_buf[0] = '\0';
-        if (OB_FAIL(get_global_proxy_config().weak_read_user_list.get(i, user_buf, static_cast<int64_t>(sizeof(user_buf))))) {
-          LOG_WARN("get weak read user list variables failed", K(ret));
-        } else{
-          if (hsr.response_.get_username().prefix_match(user_buf)){
-            is_weak_read_user = true;
-            break;
+    ObConfigStrListItem strlist_item;
+    if (OB_FAIL(get_global_config_processor().get_proxy_config_list_item(
+         addr, cluster_name, tenant_name, "weak_read_user_list", strlist_item))) {
+      LOG_WARN("get vip weak_read_user_list failed", K(addr), K(cluster_name), K(tenant_name), K(ret));
+    } else {
+      bool is_weak_read_user = false;
+      int64_t total_size = strlist_item.size();
+      if (OB_UNLIKELY(total_size > 0)) {
+        ObMysqlAuthRequest &auth_req = session_info.get_login_req();
+        ObHSRResult &hsr = auth_req.get_hsr_result();
+        char user_buf[MAX_VALUE_LENGTH];
+        for (int64_t i = 0; OB_SUCC(ret) && i < total_size; ++i) {
+          user_buf[0] = '\0';
+          if (OB_FAIL(strlist_item.get(i, user_buf, static_cast<int64_t>(sizeof(user_buf))))) {
+            LOG_WARN("get weak read user list variables failed", K(ret));
+          } else{
+            if (hsr.response_.get_username().prefix_match(user_buf)){
+              is_weak_read_user = true;
+              break;
+            }
           }
         }
       }
-    }
-    ObConfigIntItem int_item;
-    if (OB_FAIL(get_global_config_processor().get_proxy_config_int_item(
+      bool is_request_follower = false;
+      if (is_weak_read_user){
+        is_request_follower = (RequestFollower == 1);
+      } else{
+        ObConfigIntItem int_item;
+        if (OB_FAIL(get_global_config_processor().get_proxy_config_int_item(
          addr, cluster_name, tenant_name, "obproxy_read_consistency", int_item))) {
-      LOG_WARN("get vip obproxy_read_consistency failed", K(addr), K(cluster_name), K(tenant_name), K(ret));
-    } else {
-      bool is_request_follower = (RequestFollower == int_item.get_value());
+           LOG_WARN("get vip obproxy_read_consistency failed", K(addr), K(cluster_name), K(tenant_name), K(ret));
+        } else{
+          is_request_follower = (RequestFollower == int_item.get_value());
+        }
+      }
       bool is_sys_var_update = (session_info.is_request_follower_user() != is_request_follower);
       session_info.set_is_request_follower_user(is_request_follower);
-      if (is_sys_var_update || is_weak_read_user) {
+      if (is_sys_var_update) {
         ObString ob_read_consistency("ob_read_consistency");
         ObString weak;
-        if (session_info.is_request_follower_user() || is_weak_read_user) {
+        if (session_info.is_request_follower_user()) {
           weak = "2";
         } else {
           weak = "3";

--- a/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
+++ b/src/obproxy/proxy/mysql/ob_mysql_transact.cpp
@@ -6154,7 +6154,7 @@ int ObMysqlTransact::ObTransState::get_config_item(const ObString& cluster_name,
           }
         }
       }
-      bool is_request_follower = false;
+      bool is_request_follower = true;
       if (is_weak_read_user){
         is_request_follower = (RequestFollower == 1);
       } else{
@@ -6166,20 +6166,22 @@ int ObMysqlTransact::ObTransState::get_config_item(const ObString& cluster_name,
           is_request_follower = (RequestFollower == int_item.get_value());
         }
       }
-      bool is_sys_var_update = (session_info.is_request_follower_user() != is_request_follower);
-      session_info.set_is_request_follower_user(is_request_follower);
-      if (is_sys_var_update) {
-        ObString ob_read_consistency("ob_read_consistency");
-        ObString weak;
-        if (session_info.is_request_follower_user()) {
-          weak = "2";
-        } else {
-          weak = "3";
-        }
-        if (OB_FAIL(session_info.update_sys_variable(ob_read_consistency, weak))) {
-          LOG_WARN("replace user variables failed", K(weak), K(ret));
-        } else {
-          session_info.set_read_consistency_set_flag(true);
+      if (OB_SUCC(ret)) {
+        bool is_sys_var_update = (session_info.is_request_follower_user() != is_request_follower);
+        session_info.set_is_request_follower_user(is_request_follower);
+        if (is_sys_var_update) {
+          ObString ob_read_consistency("ob_read_consistency");
+          ObString weak;
+          if (session_info.is_request_follower_user()) {
+            weak = "2";
+          } else {
+            weak = "3";
+          }
+          if (OB_FAIL(session_info.update_sys_variable(ob_read_consistency, weak))) {
+            LOG_WARN("replace user variables failed", K(weak), K(ret));
+          } else {
+            session_info.set_read_consistency_set_flag(true);
+          }
         }
       }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filing this PR.
-->

### What changes were proposed in this pull request?
support weak read for specific user which can be defined in variables

### Why are the changes needed?
sometimes，we need to make read-write split on specific user

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### Will break the compatibility? How if so?

<!--
Please make sure it do not break the system compatibility, such as
  1. nGQL grammar changes;
  2. RPC protocol can't be compatible with previous;
  3. Storage format; etc.
-->

### Does this PR introduce any user-facing change?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [ ] I've run the tests to see all new and existing tests pass.
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above.
- [ ] I've informed the technical writer about the documentation change if necessary.