### PR TITLE
feat: support el9 build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,13 @@
         AM_CFLAGS="${AM_CFLAGS} -fuse-ld=lld -ffunction-sections -Wl,--no-warn-symbol-ordering,--symbol-ordering-file,${ac_abs_confdir}/hotfuncs.txt"
     fi
 
+    #check el9, add -DEL9_PlATFORM for el9
+    is_el9=`cat /proc/version | grep el9`
+    if test "$is_el9" != ""; then
+        AM_CXXFLAGS="${AM_CXXFLAGS} -DEL9_PlATFORM"
+        AM_CXXFLAGS="${AM_CXXFLAGS} -DEL9_PlATFORM"
+    fi
+
     #check gcc version, add -Wno-ignored-qualifiers flag for gcc version greater than 4.3.0
     GCC_VERSION=`$CC -dumpfullversion -dumpversion`
     if test $? -eq 0; then

--- a/configure.ac
+++ b/configure.ac
@@ -64,8 +64,8 @@
     #check el9, add -DEL9_PlATFORM for el9
     is_el9=`cat /proc/version | grep el9`
     if test "$is_el9" != ""; then
-        AM_CXXFLAGS="${AM_CXXFLAGS} -DEL9_PlATFORM"
-        AM_CXXFLAGS="${AM_CXXFLAGS} -DEL9_PlATFORM"
+        AM_CXXFLAGS="${AM_CXXFLAGS} -DEL9_PLATFORM"
+        AM_CFLAGS="${AM_CFLAGS} -DEL9_PLATFORM"
     fi
 
     #check gcc version, add -Wno-ignored-qualifiers flag for gcc version greater than 4.3.0

--- a/deps/3rd/dep_create.sh
+++ b/deps/3rd/dep_create.sh
@@ -56,6 +56,9 @@ function get_os_release() {
         version_ge "8.0" && OS_RELEASE=8 && return
         version_ge "7.0" && OS_RELEASE=7 && return
         ;;
+      almalinux)
+        version_ge "8.0" && compat_centos8 && return
+        ;;
       debian)
         version_ge "9" && compat_centos7 && return
         ;;

--- a/deps/3rd/obproxy.el8.x86_64.deps
+++ b/deps/3rd/obproxy.el8.x86_64.deps
@@ -7,7 +7,7 @@ devdeps-openssl-static-1.0.1e-3.el8.x86_64.rpm
 devdeps-libcurl-static-7.29.0-3.el8.x86_64.rpm
 devdeps-mariadb-connector-c-3.1.12-3.el8.x86_64.rpm
 devdeps-prometheus-cpp-0.8.0-4.el8.x86_64.rpm
-devdeps-gtest-1.8.0-3.el8.x86_64.rpm
+devdeps-gtest-1.8.0-132022101316.el8.x86_64.rpm
 devdeps-grpc-1.20.1-3.el8.x86_64.rpm
 devdeps-sqlite-3.38.1-5.el8.x86_64.rpm
 

--- a/src/lib/allocator/ob_mod_define.cpp
+++ b/src/lib/allocator/ob_mod_define.cpp
@@ -94,6 +94,7 @@ void ObModSet::print_mod_memory_usage(bool print_glibc) const
     _OB_LOG(INFO, "=== malloc_stats ===");
     malloc_stats();
     _OB_LOG(INFO, "=== main heap info ===");
+#ifdef EL9_PLATFORM
     struct mallinfo2 info = mallinfo2();
     _OB_LOG(INFO, "mmap_chunks=%ld", info.hblks);
     _OB_LOG(INFO, "mmap_bytes=%ld", info.hblkhd);
@@ -102,7 +103,18 @@ void ObModSet::print_mod_memory_usage(bool print_glibc) const
     _OB_LOG(INFO, "sbrk_not_in_use_chunks=%ld", info.ordblks);
     _OB_LOG(INFO, "sbrk_not_in_use_chunk_bytes=%ld", info.fordblks);
     _OB_LOG(INFO, "sbrk_top_most_releasable_chunk_bytes=%ld", info.keepcost);
+#else
+    struct mallinfo info = mallinfo();
+    _OB_LOG(INFO, "mmap_chunks=%d", info.hblks);
+    _OB_LOG(INFO, "mmap_bytes=%d", info.hblkhd);
+    _OB_LOG(INFO, "sbrk_sys_bytes=%d", info.arena);
+    _OB_LOG(INFO, "sbrk_used_chunk_bytes=%d", info.uordblks);
+    _OB_LOG(INFO, "sbrk_not_in_use_chunks=%d", info.ordblks);
+    _OB_LOG(INFO, "sbrk_not_in_use_chunk_bytes=%d", info.fordblks);
+    _OB_LOG(INFO, "sbrk_top_most_releasable_chunk_bytes=%d", info.keepcost);
+#endif
     _OB_LOG(INFO, "=== detailed malloc_info ===");
+
     //malloc_info(0, stderr);
   }
   ObObjFreeListList::get_freelists().dump();

--- a/src/lib/allocator/ob_mod_define.cpp
+++ b/src/lib/allocator/ob_mod_define.cpp
@@ -95,13 +95,13 @@ void ObModSet::print_mod_memory_usage(bool print_glibc) const
     malloc_stats();
     _OB_LOG(INFO, "=== main heap info ===");
     struct mallinfo2 info = mallinfo2();
-    _OB_LOG(INFO, "mmap_chunks=%d", info.hblks);
-    _OB_LOG(INFO, "mmap_bytes=%d", info.hblkhd);
-    _OB_LOG(INFO, "sbrk_sys_bytes=%d", info.arena);
-    _OB_LOG(INFO, "sbrk_used_chunk_bytes=%d", info.uordblks);
-    _OB_LOG(INFO, "sbrk_not_in_use_chunks=%d", info.ordblks);
-    _OB_LOG(INFO, "sbrk_not_in_use_chunk_bytes=%d", info.fordblks);
-    _OB_LOG(INFO, "sbrk_top_most_releasable_chunk_bytes=%d", info.keepcost);
+    _OB_LOG(INFO, "mmap_chunks=%ld", info.hblks);
+    _OB_LOG(INFO, "mmap_bytes=%ld", info.hblkhd);
+    _OB_LOG(INFO, "sbrk_sys_bytes=%ld", info.arena);
+    _OB_LOG(INFO, "sbrk_used_chunk_bytes=%ld", info.uordblks);
+    _OB_LOG(INFO, "sbrk_not_in_use_chunks=%ld", info.ordblks);
+    _OB_LOG(INFO, "sbrk_not_in_use_chunk_bytes=%ld", info.fordblks);
+    _OB_LOG(INFO, "sbrk_top_most_releasable_chunk_bytes=%ld", info.keepcost);
     _OB_LOG(INFO, "=== detailed malloc_info ===");
     //malloc_info(0, stderr);
   }

--- a/src/lib/allocator/ob_mod_define.cpp
+++ b/src/lib/allocator/ob_mod_define.cpp
@@ -94,7 +94,7 @@ void ObModSet::print_mod_memory_usage(bool print_glibc) const
     _OB_LOG(INFO, "=== malloc_stats ===");
     malloc_stats();
     _OB_LOG(INFO, "=== main heap info ===");
-    struct mallinfo info = mallinfo();
+    struct mallinfo2 info = mallinfo2();
     _OB_LOG(INFO, "mmap_chunks=%d", info.hblks);
     _OB_LOG(INFO, "mmap_bytes=%d", info.hblkhd);
     _OB_LOG(INFO, "sbrk_sys_bytes=%d", info.arena);

--- a/src/lib/ob_define.h
+++ b/src/lib/ob_define.h
@@ -1216,7 +1216,7 @@ inline void reset_tid_cache()
   get_tid_cache() = -1;
 }
 
-inline int64_t gettid()
+inline int64_t gettid_ob()
 {
   int64_t &tid = get_tid_cache();
   if (OB_UNLIKELY(tid <= 0)) {
@@ -1224,6 +1224,6 @@ inline int64_t gettid()
   }
   return tid;
 }
-#define GETTID() gettid()
+#define GETTID() gettid_ob()
 
 #endif // OCEANBASE_COMMON_DEFINE_H_

--- a/src/lib/random/ob_random.cpp
+++ b/src/lib/random/ob_random.cpp
@@ -35,7 +35,7 @@ int64_t ObRandom::rand(const int64_t a, const int64_t b)
 {
   static __thread uint16_t seed[3] = {0, 0, 0};
   if (0 == seed[0] && 0 == seed[1] && 0 == seed[2]) {
-    seed[0] = static_cast<uint16_t>(gettid());
+    seed[0] = static_cast<uint16_t>(GETTID());
     seed[1] = seed[0];
     seed[2] = seed[1];
     seed48(seed);

--- a/src/obproxy/cmd/ob_show_memory_handler.cpp
+++ b/src/obproxy/cmd/ob_show_memory_handler.cpp
@@ -111,7 +111,7 @@ int ObShowMemoryHandler::handle_show_memory(int event, void *data)
     }
     if (OB_SUCC(ret)) {
       // dump memory allocated by glibc
-      struct mallinfo mi = mallinfo();
+      struct mallinfo2 mi = mallinfo2();
       int64_t allocated = mi.arena + mi.hblkhd;
       int64_t used = allocated - mi.fordblks;
       if (OB_FAIL(dump_mod_memory("GLIBC", "user", allocated, used, mi.hblks))) {

--- a/src/obproxy/cmd/ob_show_memory_handler.cpp
+++ b/src/obproxy/cmd/ob_show_memory_handler.cpp
@@ -111,7 +111,11 @@ int ObShowMemoryHandler::handle_show_memory(int event, void *data)
     }
     if (OB_SUCC(ret)) {
       // dump memory allocated by glibc
+#ifdef EL9_PLATFORM
       struct mallinfo2 mi = mallinfo2();
+#else
+      struct mallinfo mi = mallinfo();
+#endif
       int64_t allocated = mi.arena + mi.hblkhd;
       int64_t used = allocated - mi.fordblks;
       if (OB_FAIL(dump_mod_memory("GLIBC", "user", allocated, used, mi.hblks))) {

--- a/src/obproxy/ob_proxy_main.cpp
+++ b/src/obproxy/ob_proxy_main.cpp
@@ -909,7 +909,7 @@ void ObProxyMain::print_memory_usage()
 
 void ObProxyMain::print_glibc_memory_usage()
 {
-  struct mallinfo mi = mallinfo();
+  struct mallinfo2 mi = mallinfo2();
   int64_t hold = mi.arena + mi.hblkhd;
   int64_t used = hold - mi.fordblks;
   int64_t count = mi.hblks;

--- a/src/obproxy/ob_proxy_main.cpp
+++ b/src/obproxy/ob_proxy_main.cpp
@@ -909,7 +909,11 @@ void ObProxyMain::print_memory_usage()
 
 void ObProxyMain::print_glibc_memory_usage()
 {
+#ifdef EL9_PLATFORM
   struct mallinfo2 mi = mallinfo2();
+#else
+  struct mallinfo mi = mallinfo();
+#endif
   int64_t hold = mi.arena + mi.hblkhd;
   int64_t used = hold - mi.fordblks;
   int64_t count = mi.hblks;

--- a/src/obproxy/proxy/mysql/ob_mysql_client_session.cpp
+++ b/src/obproxy/proxy/mysql/ob_mysql_client_session.cpp
@@ -296,7 +296,7 @@ int ObMysqlClientSession::new_connection(
     session_manager_new_.set_mutex(mutex_);
     MUTEX_TRY_LOCK(lock, mutex_, this_ethread());
     if (OB_LIKELY(lock.is_locked())) {
-      current_tid_ = gettid();
+      current_tid_ = GETTID();
       hooks_on_ = true;
 
       MYSQL_INCREMENT_DYN_STAT(CURRENT_CLIENT_CONNECTIONS);

--- a/src/obproxy/proxy/route/ob_cache_cleaner.cpp
+++ b/src/obproxy/proxy/route/ob_cache_cleaner.cpp
@@ -991,7 +991,7 @@ int ObCacheCleaner::do_delete_cluster_resource()
         cr->destroy();
       }
       LOG_INFO("this thread has clean cluster resource complete",
-               "thread_id", gettid(), KPC(cr));
+               "thread_id", GETTID(), KPC(cr));
       cr_actor->free(); // will dec cr ref
       cr_actor = NULL;
       cr = NULL;

--- a/src/obproxy/utils/ob_proxy_lib.h
+++ b/src/obproxy/utils/ob_proxy_lib.h
@@ -91,7 +91,10 @@ struct ifafilt;
 typedef unsigned int in_addr_t;
 #endif
 #include <sys/sysinfo.h>
-//#include <sys/sysctl.h>
+#ifdef EL9_PLATFORM
+#else 
+#include <sys/sysctl.h>
+#endif
 #include <dlfcn.h>
 #include <math.h>
 #include <float.h>

--- a/src/obproxy/utils/ob_proxy_lib.h
+++ b/src/obproxy/utils/ob_proxy_lib.h
@@ -91,7 +91,7 @@ struct ifafilt;
 typedef unsigned int in_addr_t;
 #endif
 #include <sys/sysinfo.h>
-#include <sys/sysctl.h>
+//#include <sys/sysctl.h>
 #include <dlfcn.h>
 #include <math.h>
 #include <float.h>


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
PR fix for #49 

support el9 build


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
use a macro `-DEL9_PLATFORM` during config process to control whether use these fixs:
1. remove `include<sys/sysctl.h>` to support higher kernel version(>5.5)
2. use ` mallinfo2` to support glic>2.33
3. rename `gettid()` to `gettid_ob()` to support glibc>2.30

This build succeeded on `Centos7 3.10.0-693.21.1.el7.x86_64` and `AlmaLinux 9.1 5.14.0-162.23.1.el9_1.x86_64`